### PR TITLE
MLE-10028async added in package.json for lower node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ dist
 
 *.DS_Store
 examples/
+cypress/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "lambdatest-cypress-cli",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lambdatest-cypress-cli",
-      "version": "2.4.8",
+      "version": "2.4.9",
       "license": "MIT",
       "dependencies": {
         "@lambdatest/node-tunnel": "^3.0.0",
         "archiver": "^5.1.0",
+        "async": "^3.2.3",
         "glob": "^7.1.6",
         "node-stream-zip": "^1.15.0",
         "request": "^2.88.2",
@@ -142,8 +143,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.0",
-      "license": "MIT"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -739,8 +741,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "license": "MIT"
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -1277,7 +1280,9 @@
       "version": "1.0.0"
     },
     "async": {
-      "version": "3.2.0"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "asynckit": {
       "version": "0.4.0"
@@ -1648,7 +1653,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5"
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@lambdatest/node-tunnel": "^3.0.0",
+    "async": "^3.2.3",
     "archiver": "^5.1.0",
     "glob": "^7.1.6",
     "node-stream-zip": "^1.15.0",


### PR DESCRIPTION
This issue(MLE-10028) is happening because of lower versions of async packages which come bundled with node js.

version lower than 3.x.x has a different format of using async.whilst.

As a fix, we are making aync as a part of package.json of cli so that whenever this module is installed we get sync version above 3