### PR TITLE
update validations for reporter config file

### DIFF
--- a/commands/default_custom_support_file.js
+++ b/commands/default_custom_support_file.js
@@ -1,6 +1,9 @@
 const addContext = require('mochawesome/addContext')
 
 // NOTE: import this file in cypress/support/e2e.js
+// import '../../custom_support_file';
+// require('../../custom_support_file');
+
 Cypress.on('test:after:run', (test, runnable) => {
     if (test.state === 'failed') {
       let item = runnable
@@ -20,9 +23,6 @@ Cypress.on('test:after:run', (test, runnable) => {
               .join(' -- ')           // this is how cypress joins the test title fragments
   
       const imageUrl = `${fullTestName} (failed).png`
-  
       addContext({ test }, imageUrl)
-      
-      
     }
   })

--- a/commands/utils/archive.js
+++ b/commands/utils/archive.js
@@ -233,7 +233,7 @@ function archive_batch(lt_config, batch) {
     } else if (!lt_config["run_settings"]["cypress_config_file"]) {
       archive.append("{}", { name: constants.CYPRESS_CONFIG_NAME });
     }
-    if (lt_config["run_settings"]["reporter_config_file"]) {
+    if (lt_config["run_settings"]["reporter_config_file"] && lt_config["run_settings"]["reporter_config_file"] !="") {
       if (fs.existsSync(lt_config["run_settings"]["reporter_config_file"])) {
         let rawdata = fs.readFileSync(
           lt_config["run_settings"]["reporter_config_file"]
@@ -244,9 +244,16 @@ function archive_batch(lt_config, batch) {
           ),
         });
       } else {
-        reject(
-          "Provided reporter config file not found. Please check the provided the value of reporter_config_file in lambdatest-config.json"
-        );
+        // case 1: reporter_config_file param is missing
+        // case 2: reporter_config_file = ""
+        // case 3: reporter_config_file = <non existing file>
+        // this shouldn't reject, instead just show a warning
+
+
+        // This warning is not required, since we are already checking for the existence of file while validate()
+        // console.log(
+        //   "Warning!! Provided reporter config file not found. Please check the provided value of reporter_config_file in lambdatest-config.json"
+        // );
       }
     }
 

--- a/commands/utils/default_config.js
+++ b/commands/utils/default_config.js
@@ -20,7 +20,7 @@ module.exports = {
     reporter_config_file: "base_reporter_config.json",
     build_name: "build-name",
     parallels: 1,
-    specs: "./*.spec.js",
+    specs: "<path_of_cypress_spec_files>",
     ignore_files: "",
     network: false,
     headless: false,

--- a/commands/utils/set_args.js
+++ b/commands/utils/set_args.js
@@ -224,6 +224,13 @@ function sync_args_from_cmd(args) {
 
     // if reporter_config_file parameter, add it in lt config alongwith a warning on console
     if (!lt_config["run_settings"]["reporter_config_file"]) {
+
+      /* cypress 9 user
+       case 1: new user (may or may not run init) -> 
+       case 2: old existing user (may or may not run init) -> 
+      */
+
+
       console.log("Warning !! Value of reporter_config_file parameter missing. Proceeding with default reporter config");
       lt_config["run_settings"]["reporter_config_file"] = constants.LT_BASE_REPORTER_CONFIG_FILE_NAME;
     }

--- a/commands/utils/validate.js
+++ b/commands/utils/validate.js
@@ -217,16 +217,21 @@ module.exports = validate_config = function (lt_config, validation_configs) {
       if (!("project" in lt_config.run_settings.smart_ui)) {
         reject("Smart UI project name is missing");
       } else if (lt_config.run_settings.smart_ui.project == "") {
-        reject("Smart UI porject name can not be blank");
+        reject("Smart UI project name can not be blank");
       }
     }
     if (
       lt_config["run_settings"]["reporter_config_file"] &&
       lt_config["run_settings"]["reporter_config_file"] != ""
     ) {
+      // console.log("reporter_config_file present");
       if (!fs.existsSync(lt_config["run_settings"]["reporter_config_file"])) {
-        reject(
-          "Error!! Reporter Config File does not exist, Pass a valid path"
+      
+
+        // case 1: cypress 9 user   -> 
+        // case 2: cypress >=10 user -> simply show warning that user may not get command logs section
+        console.log(
+          "Warning!! Reporter Config File does not exist, Commands section on dashboard may not get generated. Use lambdatest-cypress init command to generate."
         );
       } else {
         let rawdata = fs.readFileSync(
@@ -251,7 +256,7 @@ module.exports = validate_config = function (lt_config, validation_configs) {
         }
       }
     }else{
-      console.log("Warning !! Value of reporter_config_file parameter missing. Proceeding with default reporter config")
+      console.log("Warning!! Value of reporter_config_file parameter missing. Proceeding with default reporter config")
     }
 
     if (


### PR DESCRIPTION
1. dont reject test in case of base_reporter_config_file.json not present on user's system, since we noticed that users aren't running lambdatest cypress init command post installing the latest cli(old users may not want to, genuine case).


2. honour discussions done on this ticket
https://lambdatest.atlassian.net/browse/CYP-402