### PR TITLE
make auth parameter to work from cli

### DIFF
--- a/commands/utils/set_args.js
+++ b/commands/utils/set_args.js
@@ -27,7 +27,7 @@ function sync_args_from_cmd(args) {
           process.env.LT_USERNAME
         );
         lt_config["lambdatest_auth"]["username"] = process.env.LT_USERNAME;
-      }
+      } 
     } else if (
       process.env.LT_USERNAME &&
       (!("lambdatest_auth" in lt_config) ||
@@ -41,7 +41,9 @@ function sync_args_from_cmd(args) {
         lt_config["lambdatest_auth"] = {};
       }
       lt_config["lambdatest_auth"]["username"] = process.env.LT_USERNAME;
-    }
+    }else if ("username" in args && args["username"]!=""){
+      lt_config["lambdatest_auth"]["username"] = args["username"];
+    } 
 
     if (
       "lambdatest_auth" in lt_config &&
@@ -63,6 +65,8 @@ function sync_args_from_cmd(args) {
       }
       console.log("Setting access key from environment");
       lt_config["lambdatest_auth"]["access_key"] = process.env.LT_ACCESS_KEY;
+    }else if ("access_key" in args && args["access_key"]!=""){
+      lt_config["lambdatest_auth"]["access_key"] = args["access_key"];
     }
 
     if (!("browsers" in lt_config) || lt_config["browsers"].length == 0) {
@@ -371,13 +375,13 @@ function sync_args_from_cmd(args) {
     if ("exclude_specs" in lt_config["run_settings"]) {
       lt_config["run_settings"]["exclude_specs"] =
         lt_config["run_settings"]["exclude_specs"].split(",");
+        console.log(
+          "specs to exclude are",
+          lt_config["run_settings"]["exclude_specs"]
+        );
     } else {
       lt_config["run_settings"]["exclude_specs"] == [];
     }
-    console.log(
-      "specs to exclude are",
-      lt_config["run_settings"]["exclude_specs"]
-    );
 
     if ("npm-f" in args) {
       if (args["npm-f"] == "true") {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,16 @@ const argv = require("yargs")
           describe: "path of the config file",
           type: "string",
         })
+        .option("user", {
+          alias: "username",
+          describe: "Lambdatest Username of User",
+          type: "string",
+        })
+        .option("ak", {
+          alias: "access_key",
+          describe: "Lambdatest Access Key of User",
+          type: "string",
+        })
         .option("lcf", {
           alias: "lambdatest-config-file",
           describe: "path of the lambdatest config file",


### PR DESCRIPTION
1. user should be able to use` --username` and `--access_key` flag with `run`
2. `run --help` to show username and access_key flags