### PR TITLE
Add authenticated proxy support using https-proxy-agent for CONNECT t…

### DIFF
--- a/commands/build_info.js
+++ b/commands/build_info.js
@@ -40,18 +40,6 @@ function get_build_info(args) {
         );
       }
     }
-    if ("reject_unauthorized" in args) {
-      if (
-        args["reject_unauthorized"] != "false" &&
-        args["reject_unauthorized"] != "true"
-      ) {
-        console.log("reject_unauthorized has to boolean");
-        return;
-      }
-      if (args["reject_unauthorized"] == "false") {
-        console.log("Setting rejectUnauthorized to false for web requests");
-      }
-    }
     let options = {
       method: 'get',
       url: constants[env].BUILD_BASE_URL + args.buildId,
@@ -59,9 +47,26 @@ function get_build_info(args) {
         username: username,
         password: access_key,
       },
-      httpsAgent: createHttpsAgent(args["reject_unauthorized"] !== "false"),
       proxy: false,
     };
+    if ("reject_unauthorized" in args) {
+      if (
+        args["reject_unauthorized"] != "false" &&
+        args["reject_unauthorized"] != "true"
+      ) {
+        console.log("reject_unauthorized has to boolean");
+        return;
+      } else {
+        if (args["reject_unauthorized"] == "false") {
+          options.httpsAgent = createHttpsAgent(false);
+          console.log("Setting rejectUnauthorized to false for web requests");
+        } else {
+          options.httpsAgent = createHttpsAgent(true);
+        }
+      }
+    } else {
+      options.httpsAgent = createHttpsAgent(true);
+    }
 
     axios(options)
     .then(response => {

--- a/commands/build_stop.js
+++ b/commands/build_stop.js
@@ -66,18 +66,6 @@ function stop_build(args) {
       }
     }
 
-    if ("reject_unauthorized" in args) {
-      if (
-        args["reject_unauthorized"] != "false" &&
-        args["reject_unauthorized"] != "true"
-      ) {
-        console.log("reject_unauthorized has to boolean");
-        return;
-      }
-      if (args["reject_unauthorized"] == "false") {
-        console.log("Setting rejectUnauthorized to false for web requests");
-      }
-    }
     let options = {
       method: 'put',
       url: constants[env].BUILD_STOP_URL + "?buildId=" + args.build_id,
@@ -85,9 +73,27 @@ function stop_build(args) {
         Authorization: "Token " + access_key,
         Username: username,
       },
-      httpsAgent: createHttpsAgent(args["reject_unauthorized"] !== "false"),
       proxy: false,
     };
+
+    if ("reject_unauthorized" in args) {
+      if (
+        args["reject_unauthorized"] != "false" &&
+        args["reject_unauthorized"] != "true"
+      ) {
+        console.log("reject_unauthorized has to boolean");
+        return;
+      } else {
+        if (args["reject_unauthorized"] == "false") {
+          options.httpsAgent = createHttpsAgent(false);
+          console.log("Setting rejectUnauthorized to false for web requests");
+        } else {
+          options.httpsAgent = createHttpsAgent(true);
+        }
+      }
+    } else {
+      options.httpsAgent = createHttpsAgent(true);
+    }
    
     axios(options)
     .then(response => {

--- a/commands/generate_reports.js
+++ b/commands/generate_reports.js
@@ -37,11 +37,13 @@ function download_artefact(
       gzip: true,
       timeout: 120000,
       responseType: 'stream',
-      httpsAgent: createHttpsAgent(rejectUnauthorized !== false),
       proxy: false,
     };
     if (rejectUnauthorized == false) {
+      options.httpsAgent = createHttpsAgent(false);
       console.log("Setting rejectUnauthorized to false for web requests");
+    } else {
+      options.httpsAgent = createHttpsAgent(true);
     }
 
     axios(options)

--- a/commands/generate_reports.js
+++ b/commands/generate_reports.js
@@ -1,4 +1,3 @@
-const https = require('https');
 const axios = require('axios');
 const constants = require("./utils/constants.js");
 const process = require("process");
@@ -7,6 +6,7 @@ const { access } = require("fs");
 var fs = require("fs");
 const StreamZip = require("node-stream-zip");
 const path = require("path");
+const { createHttpsAgent } = require("./utils/proxy_agent.js");
 
 function download_artefact(
   username,
@@ -36,10 +36,11 @@ function download_artefact(
       },
       gzip: true,
       timeout: 120000,
-      responseType: 'stream'
+      responseType: 'stream',
+      httpsAgent: createHttpsAgent(rejectUnauthorized !== false),
+      proxy: false,
     };
     if (rejectUnauthorized == false) {
-      options.httpsAgent = new https.Agent({ rejectUnauthorized: false });
       console.log("Setting rejectUnauthorized to false for web requests");
     }
 

--- a/commands/utils/batch/batch_runner.js
+++ b/commands/utils/batch/batch_runner.js
@@ -13,6 +13,7 @@ const builds = require("../poller/build");
 const batcher = require("./batcher.js");
 const reports = require("../../../commands/generate_reports.js");
 const { fail } = require("yargs");
+const https = require('https');
 const axios = require('axios');
 const converter=require("../../../converter/converter.js");
 const { createHttpsAgent } = require("../proxy_agent.js");
@@ -289,13 +290,7 @@ function downloadHyperExecuteCLI(env) {
     }
     const file = fs.createWriteStream(filePath);
 
-    const proxyUrl = process.env.HTTPS_PROXY ||
-                     process.env.https_proxy ||
-                     process.env.HTTP_PROXY ||
-                     process.env.http_proxy;
-    const downloadOptions = proxyUrl
-      ? { agent: new (require('https-proxy-agent'))(proxyUrl) }
-      : {};
+    const downloadOptions = { agent: createHttpsAgent(true) };
 
     https.get(downloadUrl, downloadOptions, (response) => {
       response.pipe(file);

--- a/commands/utils/batch/batch_runner.js
+++ b/commands/utils/batch/batch_runner.js
@@ -26,9 +26,13 @@ function run_test(payload, env = "prod", rejectUnauthorized,lt_config) {
     let options = {
       url: constants[env].INTEGRATION_BASE_URL + constants.RUN_URL,
       data: payload,
-      httpsAgent: createHttpsAgent(rejectUnauthorized !== false),
       proxy: false,
     };
+    if (rejectUnauthorized == false) {
+      options.httpsAgent = createHttpsAgent(false);
+    } else {
+      options.httpsAgent = createHttpsAgent(true);
+    }
     let responseData = null;
     getFeatureFlags(
       lt_config["lambdatest_auth"]["username"],

--- a/commands/utils/poller/build.js
+++ b/commands/utils/poller/build.js
@@ -1,6 +1,6 @@
 const constants = require("../constants");
-const https = require('https');
 const axios = require('axios');
+const { createHttpsAgent } = require("../proxy_agent.js");
 //https://api.cypress-v3.dev.lambdatest.io/api/v1/test/stop/?sessionId=4a7434b9-1905-4aaf-a178-9167acb00c5d
 function stop_cypress_session(lt_config, session_id, env) {
   return new Promise(function (resolve, reject) {
@@ -11,10 +11,9 @@ function stop_cypress_session(lt_config, session_id, env) {
         Username: lt_config["lambdatest_auth"]["username"],
       },
       method: "PUT",
+      httpsAgent: createHttpsAgent(lt_config.run_settings.reject_unauthorized !== false),
+      proxy: false,
     };
-    if (lt_config.run_settings.reject_unauthorized == false) {
-      options.httpsAgent = new https.Agent({ rejectUnauthorized: false });
-    }
 
     axios(options)
     .then(response => {

--- a/commands/utils/poller/build.js
+++ b/commands/utils/poller/build.js
@@ -11,9 +11,13 @@ function stop_cypress_session(lt_config, session_id, env) {
         Username: lt_config["lambdatest_auth"]["username"],
       },
       method: "PUT",
-      httpsAgent: createHttpsAgent(lt_config.run_settings.reject_unauthorized !== false),
       proxy: false,
     };
+    if (lt_config.run_settings.reject_unauthorized == false) {
+      options.httpsAgent = createHttpsAgent(false);
+    } else {
+      options.httpsAgent = createHttpsAgent(true);
+    }
 
     axios(options)
     .then(response => {

--- a/commands/utils/poller/build_stats.js
+++ b/commands/utils/poller/build_stats.js
@@ -12,9 +12,14 @@ function get_completed_build_info(lt_config, session_id, env) {
       username: lt_config["lambdatest_auth"]["username"],
       password: lt_config["lambdatest_auth"]["access_key"],
     },
-    httpsAgent: createHttpsAgent(lt_config.run_settings.reject_unauthorized !== false),
     proxy: false,
   };
+
+  if (lt_config.run_settings.reject_unauthorized == false) {
+    options.httpsAgent = createHttpsAgent(false);
+  } else {
+    options.httpsAgent = createHttpsAgent(true);
+  }
 
   return new Promise(function (resolve, reject) {
     axios(options)
@@ -53,9 +58,14 @@ function get_build_info(lt_config, session_id,hyperexecute, env, update_status, 
       username: lt_config["lambdatest_auth"]["username"],
       password: lt_config["lambdatest_auth"]["access_key"],
     },
-    httpsAgent: createHttpsAgent(lt_config.run_settings.reject_unauthorized !== false),
     proxy: false,
   };
+
+  if (lt_config.run_settings.reject_unauthorized == false) {
+    options.httpsAgent = createHttpsAgent(false);
+  } else {
+    options.httpsAgent = createHttpsAgent(true);
+  }
 
   axios(options)
   .then(async response => {

--- a/commands/utils/poller/build_stats.js
+++ b/commands/utils/poller/build_stats.js
@@ -1,7 +1,7 @@
 const constants = require("../constants");
 const builds = require("./build");
-const https = require('https');
 const axios = require('axios');
+const { createHttpsAgent } = require("../proxy_agent.js");
 var get_build_info_count = 0;
 
 function get_completed_build_info(lt_config, session_id, env) {
@@ -12,11 +12,9 @@ function get_completed_build_info(lt_config, session_id, env) {
       username: lt_config["lambdatest_auth"]["username"],
       password: lt_config["lambdatest_auth"]["access_key"],
     },
+    httpsAgent: createHttpsAgent(lt_config.run_settings.reject_unauthorized !== false),
+    proxy: false,
   };
-
-  if (lt_config.run_settings.reject_unauthorized == false) {
-    options.httpsAgent = new https.Agent({ rejectUnauthorized: false });
-  }
 
   return new Promise(function (resolve, reject) {
     axios(options)
@@ -55,11 +53,9 @@ function get_build_info(lt_config, session_id,hyperexecute, env, update_status, 
       username: lt_config["lambdatest_auth"]["username"],
       password: lt_config["lambdatest_auth"]["access_key"],
     },
+    httpsAgent: createHttpsAgent(lt_config.run_settings.reject_unauthorized !== false),
+    proxy: false,
   };
-
-  if (lt_config.run_settings.reject_unauthorized == false) {
-    options.httpsAgent = new https.Agent({ rejectUnauthorized: false });
-  }
 
   axios(options)
   .then(async response => {
@@ -189,6 +185,8 @@ function fetchHyperExecuteJobStatus(jobId, env, username, accessKey) {
       username: username,
       password: accessKey,
     },
+    httpsAgent: createHttpsAgent(true),
+    proxy: false,
   };
 
   return new Promise((resolve, reject) => {

--- a/commands/utils/proxy_agent.js
+++ b/commands/utils/proxy_agent.js
@@ -1,0 +1,31 @@
+const https = require('https');
+const url = require('url');
+const HttpsProxyAgent = require('https-proxy-agent');
+
+/**
+ * Creates an HTTPS agent that supports authenticated proxy servers
+ * via HTTPS_PROXY/HTTP_PROXY environment variables and respects
+ * the rejectUnauthorized SSL setting.
+ *
+ * @param {boolean} rejectUnauthorized - Whether to reject unauthorized SSL certs (default: true)
+ * @returns {https.Agent} Configured HTTPS agent
+ */
+function createHttpsAgent(rejectUnauthorized = true) {
+  const proxyUrl = process.env.HTTPS_PROXY ||
+                   process.env.https_proxy ||
+                   process.env.HTTP_PROXY ||
+                   process.env.http_proxy;
+
+  if (proxyUrl) {
+    // https-proxy-agent v5 accepts a string URL or a url.parse() result object.
+    // We parse it ourselves so we can merge in rejectUnauthorized for the
+    // target TLS connection (used after the CONNECT tunnel is established).
+    const parsed = url.parse(proxyUrl);
+    parsed.rejectUnauthorized = rejectUnauthorized;
+    return new HttpsProxyAgent(parsed);
+  }
+
+  return new https.Agent({ rejectUnauthorized: rejectUnauthorized });
+}
+
+module.exports = { createHttpsAgent };

--- a/commands/utils/proxy_agent.js
+++ b/commands/utils/proxy_agent.js
@@ -1,6 +1,5 @@
 const https = require('https');
-const url = require('url');
-const HttpsProxyAgent = require('https-proxy-agent');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 /**
  * Creates an HTTPS agent that supports authenticated proxy servers
@@ -17,15 +16,10 @@ function createHttpsAgent(rejectUnauthorized = true) {
                    process.env.http_proxy;
 
   if (proxyUrl) {
-    // https-proxy-agent v5 accepts a string URL or a url.parse() result object.
-    // We parse it ourselves so we can merge in rejectUnauthorized for the
-    // target TLS connection (used after the CONNECT tunnel is established).
-    const parsed = url.parse(proxyUrl);
-    parsed.rejectUnauthorized = rejectUnauthorized;
-    return new HttpsProxyAgent(parsed);
+    return new HttpsProxyAgent(proxyUrl, { rejectUnauthorized });
   }
 
-  return new https.Agent({ rejectUnauthorized: rejectUnauthorized });
+  return new https.Agent({ rejectUnauthorized });
 }
 
 module.exports = { createHttpsAgent };

--- a/commands/utils/uploader.js
+++ b/commands/utils/uploader.js
@@ -15,9 +15,14 @@ function get_signed_url(lt_config, prefix, env = "prod") {
     }
     let options = {
       headers: api_headers,
-      httpsAgent: createHttpsAgent(lt_config.run_settings.reject_unauthorized !== false),
       proxy: false,
     };
+
+    if (lt_config.run_settings.reject_unauthorized == false) {
+      options.httpsAgent = createHttpsAgent(false);
+    } else {
+      options.httpsAgent = createHttpsAgent(true);
+    }
     let data = {
       Username: lt_config['lambdatest_auth']['username'],
       token: lt_config['lambdatest_auth']['access_key'],
@@ -78,9 +83,14 @@ function upload_zip(lt_config, file_name, prefix = "project", env = "prod") {
           headers: {
             'Content-Type': 'application/zip',
           },
-          httpsAgent: createHttpsAgent(lt_config.run_settings.reject_unauthorized !== false),
           proxy: false,
         };
+
+        if (lt_config.run_settings.reject_unauthorized == false) {
+          options.httpsAgent = createHttpsAgent(false);
+        } else {
+          options.httpsAgent = createHttpsAgent(true);
+        }
 
         axios.put(url, formData, options)
         .then(response => {

--- a/commands/utils/validate_cli.js
+++ b/commands/utils/validate_cli.js
@@ -9,9 +9,13 @@ function validate_cli(env = "prod", rejectUnauthorized) {
     let options = {
       method: 'get',
       url: requestUrl,
-      httpsAgent: createHttpsAgent(rejectUnauthorized !== false),
       proxy: false,
     };
+    if (rejectUnauthorized == false) {
+      options.httpsAgent = createHttpsAgent(false);
+    } else {
+      options.httpsAgent = createHttpsAgent(true);
+    }
 
     console.log("[DEBUG] Request URL:", requestUrl);
     console.log("[DEBUG] rejectUnauthorized:", rejectUnauthorized);

--- a/commands/utils/validate_cli.js
+++ b/commands/utils/validate_cli.js
@@ -1,24 +1,36 @@
-const https = require('https');
 const axios = require('axios');
 const constants = require("./constants.js");
+const { createHttpsAgent } = require("./proxy_agent.js");
 
 function validate_cli(env = "prod", rejectUnauthorized) {
   console.log("Validating CLI");
   return new Promise(function (resolve, reject) {
+    let requestUrl = constants[env].INTEGRATION_BASE_URL + constants.CLI;
     let options = {
       method: 'get',
-      url: constants[env].INTEGRATION_BASE_URL + constants.CLI,
+      url: requestUrl,
+      httpsAgent: createHttpsAgent(rejectUnauthorized !== false),
+      proxy: false,
     };
-    if (rejectUnauthorized == false) {
-      options.httpsAgent = new https.Agent({ rejectUnauthorized: false });
-    }
-   
+
+    console.log("[DEBUG] Request URL:", requestUrl);
+    console.log("[DEBUG] rejectUnauthorized:", rejectUnauthorized);
+    console.log("[DEBUG] HTTP_PROXY:", process.env.HTTP_PROXY || process.env.http_proxy || "not set");
+    console.log("[DEBUG] HTTPS_PROXY:", process.env.HTTPS_PROXY || process.env.https_proxy || "not set");
+    console.log("[DEBUG] NO_PROXY:", process.env.NO_PROXY || process.env.no_proxy || "not set");
+
     axios(options)
     .then(response => {
+      console.log("[DEBUG] Response status:", response.status);
+      console.log("[DEBUG] Response headers:", JSON.stringify(response.headers));
+      console.log("[DEBUG] Response body:", JSON.stringify(response.data));
       resolve(response.data);
     })
     .catch(error => {
     if (error.response) {
+      console.log("[DEBUG] Error response status:", error.response.status);
+      console.log("[DEBUG] Error response headers:", JSON.stringify(error.response.headers));
+      console.log("[DEBUG] Error response data (first 500 chars):", String(error.response.data).substring(0, 500));
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx
       if (error.response.status != 200 && error.response.status != 202) {
@@ -35,9 +47,12 @@ function validate_cli(env = "prod", rejectUnauthorized) {
       // The request was made but no response was received
       // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
       // http.ClientRequest in node.js
+      console.log("[DEBUG] No response received. Error code:", error.code);
+      console.log("[DEBUG] Error message:", error.message);
       console.log(error.cause);
       reject(error.cause);
     } else {
+      console.log("[DEBUG] Request setup error:", error.message);
       console.log(error);
       reject(error);
     }

--- a/commands/utils/validate_cli.js
+++ b/commands/utils/validate_cli.js
@@ -17,24 +17,12 @@ function validate_cli(env = "prod", rejectUnauthorized) {
       options.httpsAgent = createHttpsAgent(true);
     }
 
-    console.log("[DEBUG] Request URL:", requestUrl);
-    console.log("[DEBUG] rejectUnauthorized:", rejectUnauthorized);
-    console.log("[DEBUG] HTTP_PROXY:", process.env.HTTP_PROXY || process.env.http_proxy || "not set");
-    console.log("[DEBUG] HTTPS_PROXY:", process.env.HTTPS_PROXY || process.env.https_proxy || "not set");
-    console.log("[DEBUG] NO_PROXY:", process.env.NO_PROXY || process.env.no_proxy || "not set");
-
     axios(options)
     .then(response => {
-      console.log("[DEBUG] Response status:", response.status);
-      console.log("[DEBUG] Response headers:", JSON.stringify(response.headers));
-      console.log("[DEBUG] Response body:", JSON.stringify(response.data));
       resolve(response.data);
     })
     .catch(error => {
     if (error.response) {
-      console.log("[DEBUG] Error response status:", error.response.status);
-      console.log("[DEBUG] Error response headers:", JSON.stringify(error.response.headers));
-      console.log("[DEBUG] Error response data (first 500 chars):", String(error.response.data).substring(0, 500));
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx
       if (error.response.status != 200 && error.response.status != 202) {
@@ -51,12 +39,9 @@ function validate_cli(env = "prod", rejectUnauthorized) {
       // The request was made but no response was received
       // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
       // http.ClientRequest in node.js
-      console.log("[DEBUG] No response received. Error code:", error.code);
-      console.log("[DEBUG] Error message:", error.message);
       console.log(error.cause);
       reject(error.cause);
     } else {
-      console.log("[DEBUG] Request setup error:", error.message);
       console.log(error);
       reject(error);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.6.5",
         "dotenv": "^16.3.1",
         "glob": "^7.1.6",
+        "https-proxy-agent": "^7.0.6",
         "mochawesome": "^7.1.3",
         "node-stream-zip": "^1.15.0",
         "semver": "^7.3.5",
@@ -145,6 +146,31 @@
         "split": "^1.0.1"
       }
     },
+    "node_modules/@lambdatest/node-tunnel/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@lambdatest/node-tunnel/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -165,14 +191,12 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -937,15 +961,16 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.6.5",
     "dotenv": "^16.3.1",
     "glob": "^7.1.6",
+    "https-proxy-agent": "^7.0.6",
     "mochawesome": "^7.1.3",
     "node-stream-zip": "^1.15.0",
     "semver": "^7.3.5",


### PR DESCRIPTION
…unneling

Axios's built-in proxy handling sends HTTPS requests as plain HTTP to the proxy instead of using CONNECT tunneling, causing infinite redirect loops when all LambdaTest API endpoints are HTTPS. This adds a shared createHttpsAgent() utility that uses https-proxy-agent (already available as a transitive dep) to establish proper CONNECT tunnels with Proxy-Authorization when HTTPS_PROXY/HTTP_PROXY env vars are set.

Updated all 8 files (14 call sites) that make axios/https requests. Also fixes a bug in uploader.js where axios.put() was passed `headers` instead of `options`, silently ignoring the httpsAgent config.